### PR TITLE
- don't use snapper factory

### DIFF
--- a/agent-snapper/src/SnapperAgent.cc
+++ b/agent-snapper/src/SnapperAgent.cc
@@ -99,7 +99,8 @@ SnapperAgent::~SnapperAgent()
 {
     if (sh)
     {
-	deleteSnapper(sh);
+	delete sh;
+	sh = 0;
     }
 }
 
@@ -344,11 +345,13 @@ YCPValue SnapperAgent::Execute(const YCPPath &path, const YCPValue& arg,
 	if (sh)
 	{
 	    y2milestone ("deleting existing snapper object");
-	    deleteSnapper(sh);
+	    delete sh;
+	    sh = 0;
 	}
 	string config_name = getValue (argmap, YCPString ("config"), "root");
-	try {
-	    sh = createSnapper (config_name);
+	try
+	{
+	    sh = new Snapper(config_name);
 	}
 	catch (const ConfigNotFoundException& e)
 	{

--- a/agent-snapper/src/SnapperAgent.h
+++ b/agent-snapper/src/SnapperAgent.h
@@ -14,7 +14,6 @@
 #include <scr/SCRAgent.h>
 
 #include <snapper/Snapper.h>
-#include <snapper/Factory.h>
 #include <snapper/Snapshot.h>
 #include <snapper/Comparison.h>
 #include <snapper/File.h>


### PR DESCRIPTION
Don't use the snapper factory. It's not a good idea after all since it uses a global destructor and
ordering of global destructors is undefined and that can cause trouble.
