### PR TITLE
Delete, show and modify buttons only can be pressed if some snapshot is present.

### DIFF
--- a/package/yast2-snapper.changes
+++ b/package/yast2-snapper.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 18 11:15:53 UTC 2015 - teclator@gmail.com
+
+- disable delete and modify snapshots if not exist (bsc#951179)
+- 3.1.10
+
+-------------------------------------------------------------------
 Mon Jun 15 16:18:54 CEST 2015 - aschnell@suse.de
 
 - removed noarch tag again (bsc#934856)

--- a/package/yast2-snapper.spec
+++ b/package/yast2-snapper.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-snapper
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 Group:		System/YaST
 

--- a/src/include/snapper/dialogs.rb
+++ b/src/include/snapper/dialogs.rb
@@ -317,12 +317,12 @@ module Yast
       UI.ChangeWidget(
         Id("post"),
         :Enabled,
-        Ops.greater_than(Builtins.size(pre_items), 0)
+	!pre_items.empty?
       )
       UI.ChangeWidget(
         Id(:pre_list),
         :Enabled,
-        Ops.greater_than(Builtins.size(pre_items), 0)
+	!pre_items.empty?
       )
 
       ret = nil
@@ -473,7 +473,7 @@ module Yast
         Popup.ClearFeedback
 
         UI.ChangeWidget(Id(:snapshots_table), :Items, get_snapshot_items.call)
-	enable_snapshot_buttons(Ops.greater_than(Builtins.size(snapshot_items), 0))
+	enable_snapshot_buttons(!snapshot_items.empty?)
 
         nil
       end
@@ -524,11 +524,11 @@ module Yast
       Wizard.HideAbortButton
 
       UI.SetFocus(Id(:snapshots_table))
-      enable_snapshot_buttons(snapshot_items != [])
+      enable_snapshot_buttons(!snapshot_items.empty?)
       UI.ChangeWidget(
         Id(:configs),
         :Enabled,
-        Ops.greater_than(Builtins.size(configs), 1)
+	configs.size > 1
       )
 
       ret = nil

--- a/src/include/snapper/dialogs.rb
+++ b/src/include/snapper/dialogs.rb
@@ -94,6 +94,14 @@ module Yast
       ret
     end
 
+    
+    # grouped enable condition based on snapshot presence for modification widgets
+    def enable_snapshot_buttons(condition)
+      UI.ChangeWidget(Id(:show), :Enabled, condition) 
+      UI.ChangeWidget(Id(:modify), :Enabled, condition)
+      UI.ChangeWidget(Id(:delete), :Enabled, condition)
+    end
+
 
     # Popup for modification of existing snapshot
     # @return true if new snapshot was created
@@ -465,11 +473,7 @@ module Yast
         Popup.ClearFeedback
 
         UI.ChangeWidget(Id(:snapshots_table), :Items, get_snapshot_items.call)
-        UI.ChangeWidget(
-          Id(:show),
-          :Enabled,
-          Ops.greater_than(Builtins.size(snapshot_items), 0)
-        )
+	enable_snapshot_buttons(Ops.greater_than(Builtins.size(snapshot_items), 0))
 
         nil
       end
@@ -520,7 +524,7 @@ module Yast
       Wizard.HideAbortButton
 
       UI.SetFocus(Id(:snapshots_table))
-      UI.ChangeWidget(Id(:show), :Enabled, false) if snapshot_items == []
+      enable_snapshot_buttons(snapshot_items != [])
       UI.ChangeWidget(
         Id(:configs),
         :Enabled,


### PR DESCRIPTION
The user could press modify and delete buttons even when no snapshot exist, so we just disable also those buttons based on that condition.

Fixed [bsc#951179](https://bugzilla.suse.com/show_bug.cgi?id=951179).
