### PR TITLE
Fix restore selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ tmp.*
 *.log
 *.ybc
 test-driver
+
+/.yardoc
+/doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
-language: cpp
-compiler:
-    - gcc
+sudo: required
+language: bash
+services:
+  - docker
+
 before_install:
-    # disable rvm, use system Ruby
-    - rvm reset
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2" -g "yast-rake rspec gettext ruby-dbus"
+  - docker build -t yast-snapper-image .
+  # list the installed packages (just for easier debugging)
+  - docker run --rm -it yast-snapper-image rpm -qa | sort
+
 script:
-    - rake check:syntax
-    - rake check:pot
-    - make -f Makefile.cvs
-    - make
-    - rake test:unit
-    - sudo make install
+  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-snapper-image yast-travis-ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/ruby:sle12-sp2
+COPY . /usr/src/app
+

--- a/package/yast2-snapper.changes
+++ b/package/yast2-snapper.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 24 08:42:11 UTC 2018 - knut.anderssen@suse.com
+
+- Use the correct snapshot number when restoring selected massively
+  (bsc#956955)
+- 3.1.10
+
+-------------------------------------------------------------------
 Mon Jun 15 16:18:54 CEST 2015 - aschnell@suse.de
 
 - removed noarch tag again (bsc#934856)

--- a/package/yast2-snapper.changes
+++ b/package/yast2-snapper.changes
@@ -3,6 +3,7 @@ Tue Jul 24 08:42:11 UTC 2018 - knut.anderssen@suse.com
 
 - Use the correct snapshot number when restoring selected massively
   (bsc#956955)
+- Use the sle12sp2 Docker for Travis image.
 - 3.1.10
 
 -------------------------------------------------------------------

--- a/package/yast2-snapper.spec
+++ b/package/yast2-snapper.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-snapper
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 Group:		System/YaST
 

--- a/src/include/snapper/dialogs.rb
+++ b/src/include/snapper/dialogs.rb
@@ -937,7 +937,7 @@ module Yast
                 HSpacing(0.5)
               )
             )
-            show_file_modification.call(current_file, pre_num, snapshot_num)
+            show_file_modification.call(current_file, from, to)
           end
         else
           UI.ReplaceWidget(Id(:diff_chooser), VBox(VStretch()))
@@ -955,7 +955,7 @@ module Yast
           Right(Label(date))
         )
       else
-        tree_label = "%{pre} && %{post}" % { :pre => pre_num, :post => snapshot_num }
+        tree_label = "%{pre} && %{post}" % { :pre => from, :post => to }
         date_widget = VBox(
           HBox(
             # label, date string will follow at the end of line
@@ -1092,10 +1092,8 @@ module Yast
         elsif ret == :diff_snapshot
           if type == :SINGLE
             UI.ChangeWidget(Id(:selection_snapshots), :Enabled, false)
-            show_file_modification.call(current_file, snapshot_num, 0)
-          else
-            show_file_modification.call(current_file, pre_num, snapshot_num)
           end
+          show_file_modification.call(current_file, from, to)
 
         elsif ret == :diff_arbitrary || ret == :selection_snapshots
           UI.ChangeWidget(Id(:selection_snapshots), :Enabled, true)
@@ -1166,10 +1164,10 @@ module Yast
                     "from snapshot '%2' to current system?"
                 ),
                 Snapper.GetFileFullPath(current_filename),
-                snapshot_num
+                from
               )
             )
-            Snapper.RestoreFiles(snapshot_num, [current_filename])
+            Snapper.RestoreFiles(from, [current_filename])
           end
           next
 
@@ -1205,7 +1203,7 @@ module Yast
                     "<p>Files existing in original snapshot will be copied to current system.</p>\n" +
                     "<p>Files that did not exist in the snapshot will be deleted.</p>Are you sure?"
                 ),
-                pre_num,
+                from,
                 to_restore.join("<br>")
               ),
               60,
@@ -1214,7 +1212,7 @@ module Yast
               Label.NoButton,
               :focus_no
             )
-            Snapper.RestoreFiles(pre_num, filenames)
+            Snapper.RestoreFiles(from, filenames)
             break
           end
           next


### PR DESCRIPTION
- Trello Card: https://trello.com/c/VYBh3FRs/140-sled12-sp1-p3-956955-yast2-snapper-fails-to-restore-previous-version-of-file
- https://bugzilla.suse.com/show_bug.cgi?id=956955

## Before the fix

![snapperrestoreselectedbug](https://user-images.githubusercontent.com/7056681/43128092-fb5d2dd2-8f28-11e8-9612-7fb116362ca1.png)

## After the fix

![snapperrestoreselected](https://user-images.githubusercontent.com/7056681/43128095-fd534964-8f28-11e8-90ae-bd0191565f38.png)

## Would be nice

In the list of files there is no information about which will be deleted and which will be restored, it maybe would be nice to have a note like when we perform the restore:

![image](https://user-images.githubusercontent.com/7056681/43128247-65fce33a-8f29-11e8-88d9-1105b459d2be.png)
