### PR TITLE
Stop using last argument as keyword parameters

### DIFF
--- a/package/yast2-snapper.changes
+++ b/package/yast2-snapper.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 24 09:44:41 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Do not crash when trying to show found differences
+  between snapshots (bsc#1195021).
+- 4.4.2
+
+-------------------------------------------------------------------
 Tue Apr 20 18:14:05 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - stop packaging docdir, it only contained the license which

--- a/package/yast2-snapper.spec
+++ b/package/yast2-snapper.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-snapper
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST - file system snapshots review
 License:        GPL-2.0-only

--- a/src/modules/Snapper.rb
+++ b/src/modules/Snapper.rb
@@ -149,7 +149,7 @@ module Yast
         # the file diff
         elsif Ops.get(out, "stdout") != ""
           status = ["diff"]
-          ret["diff"] = out["stdout"].encode(Encoding::UTF_8, invalid: :replace)
+          ret["diff"] = out["stdout"].encode(Encoding::UTF_8, invalid: :replace) # rubocop:disable Style/HashSyntax
         end
 
         # check mode and ownerships

--- a/src/modules/Snapper.rb
+++ b/src/modules/Snapper.rb
@@ -149,7 +149,7 @@ module Yast
         # the file diff
         elsif Ops.get(out, "stdout") != ""
           status = ["diff"]
-          ret["diff"] = out["stdout"].encode(Encoding::UTF_8, invalid: :replace) # rubocop:disable Style/HashSyntax
+          ret["diff"] = out["stdout"].encode(Encoding::UTF_8, :invalid => :replace)
         end
 
         # check mode and ownerships

--- a/src/modules/Snapper.rb
+++ b/src/modules/Snapper.rb
@@ -149,7 +149,7 @@ module Yast
         # the file diff
         elsif Ops.get(out, "stdout") != ""
           status = ["diff"]
-          ret["diff"] = out["stdout"].encode(Encoding::UTF_8, { :invalid => :replace })
+          ret["diff"] = out["stdout"].encode(Encoding::UTF_8, invalid: :replace)
         end
 
         # check mode and ownerships

--- a/test/snapper_test.rb
+++ b/test/snapper_test.rb
@@ -5,6 +5,27 @@ require_relative "test_helper"
 Yast.import "Snapper"
 
 describe Yast::Snapper do
+  describe "GetFileModification" do
+    # Quite mocking test just for ensuring bsc#1195021 does not happen again
+    context "when there are differences" do
+      before do
+        allow(subject).to receive(:GetSnapshotPath).with(anything).and_return("")
+        allow(Yast::SCR).to receive(:Execute).with(anything, /diff/)
+          .and_return({ "stderr" => "", "stdout" => "Found differences: \xA1 \xA1" })
+        allow(Yast::SCR).to receive(:Execute).with(anything, /ls/)
+          .and_return("mode1 user1 group1 mode2 mode2 user2 group2")
+        allow(Yast::FileUtils).to receive(:Exists).and_return(true)
+      end
+
+      it "does not crash while encoding" do
+        result = subject.GetFileModification("fake_file_1", 2, 3)
+
+        expect(result).to be_a(Hash)
+        expect(result["diff"]).to include("Found differences")
+      end
+    end
+  end
+
   describe "#userdata_to_string" do
     it "call with empty userdata" do
       expect(Yast::Snapper.userdata_to_string({})).to eq("")


### PR DESCRIPTION
To avoid crashing with a `no implicit conversion of Hash into String (TypeError)` in Ruby >= 3, already warned in previous versions.

https://bugzilla.suse.com/show_bug.cgi?id=1195021