### PR TITLE
Fixed Translations

### DIFF
--- a/package/yast2-snapper.changes
+++ b/package/yast2-snapper.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr  4 08:56:07 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed translations: Moved variable message part out of _(...)
+  (bsc#1209956)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-snapper.spec
+++ b/package/yast2-snapper.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-snapper
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST - file system snapshots review
 License:        GPL-2.0-only

--- a/src/modules/Snapper.rb
+++ b/src/modules/Snapper.rb
@@ -93,7 +93,7 @@ module Yast
       return SnapperDbus.get_config(@current_config)
 
     rescue Exception => e
-      Report.Error(_("Failed to get config:" + "\n" + e.message))
+      Report.Error(_("Failed to get config:") + "\n" + e.message)
       return {}
     end
 
@@ -110,7 +110,7 @@ module Yast
       return SnapperDbus.get_mount_point(@current_config, snapshot_num)
 
     rescue Exception => e
-      Report.Error(_("Failed to get snapshot mount point:" + "\n" + e.message))
+      Report.Error(_("Failed to get snapshot mount point:") + "\n" + e.message)
       return ""
     end
 
@@ -247,7 +247,7 @@ module Yast
       return true
 
     rescue Exception => e
-      Report.Error(_("Failed to create new snapshot:" + "\n" + e.message))
+      Report.Error(_("Failed to create new snapshot:") + "\n" + e.message)
       return false
     end
 
@@ -260,7 +260,7 @@ module Yast
       return true
 
     rescue Exception => e
-      Report.Error(_("Failed to modify snapshot:" + "\n" + e.message))
+      Report.Error(_("Failed to modify snapshot:") + "\n" + e.message)
       return false
     end
 
@@ -272,7 +272,7 @@ module Yast
       return true
 
     rescue Exception => e
-      Report.Error(_("Failed to delete snapshot:" + "\n" + e.message))
+      Report.Error(_("Failed to delete snapshot:") + "\n" + e.message)
       return false
     end
 


### PR DESCRIPTION
## Target Branch / Release

_**This is for SLE-15-SP5**_. A merge to _master_ will follow.

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1209956


## Problem

Some messages are not translated.


## Cause

In several cases, this uses the `_(...)`  translation function in the wrong way: It concatenates messages that consist of a static part (which is translated) and a variable part (which may not be):

```
  _("User message:" + "\n" + detailed_error)  # WRONG!
```

**This is wrong.**

This needs to be done _outside_ of the `_(...)` function:

If messages are concatenated (string + string), it always needs to be
OUTSIDE of _(...), never inside:

```
  _("User message:") + "\n" + detailed_error
```

## Background

The message inside `_(...)` is used as the key to find a translation in one of the `.mo` files:


```
  msgid "User message:"
  msgstr "Benutzernachricht:"   # Translation

  msgid "Foo"
  msgstr "DE-Foo"
```

Of course, that only works if the _msgid_ is constant. If you string-add something to it, it's no longer constant, and the _msgid_ is not found in the translations file, which means that it will remain untranslated.


## Fix

Moved the variable part out of  `_(...)`.


## Target Release

`git blame` tells us that this has been broken for the last 8 years, i.e. for all the life time of _yast-snapper_. Those messages were _never_ shown in the correct translation.

We'll restrict this fix to the upcoming releases, SLE-15-SP5 and Factory / Tumbleweed.