### PR TITLE
Backport SP6

### DIFF
--- a/package/yast2-snapper.changes
+++ b/package/yast2-snapper.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.2
 
 -------------------------------------------------------------------
 Tue Apr  4 08:56:07 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>

--- a/package/yast2-snapper.spec
+++ b/package/yast2-snapper.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-snapper
-Version:        4.6.0
+Version:        4.6.2
 Release:        0
 Summary:        YaST - file system snapshots review
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.


## Solution

just bump version as fix from TW is already in SP5